### PR TITLE
Add APIServerSLILatency_kusto metric and update load test config

### DIFF
--- a/clusterloader2/go.mod
+++ b/clusterloader2/go.mod
@@ -34,6 +34,7 @@ replace (
 )
 
 require (
+	github.com/Azure/azure-kusto-go/azkustodata v1.1.0
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.19.1
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.11.0
 	github.com/go-errors/errors v1.5.1
@@ -102,6 +103,8 @@ require (
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/prometheus/client_golang v1.22.0 // indirect
 	github.com/prometheus/procfs v0.15.1 // indirect
+	github.com/samber/lo v1.49.1 // indirect
+	github.com/shopspring/decimal v1.4.0 // indirect
 	github.com/uber/jaeger-client-go v2.25.0+incompatible // indirect
 	github.com/uber/jaeger-lib v2.4.0+incompatible // indirect
 	github.com/x448/float16 v0.8.4 // indirect

--- a/clusterloader2/go.sum
+++ b/clusterloader2/go.sum
@@ -41,6 +41,8 @@ cloud.google.com/go/storage v1.8.0/go.mod h1:Wv1Oy7z6Yz3DshWRJFhqM/UCfaWIRTdp0RX
 cloud.google.com/go/storage v1.10.0/go.mod h1:FLPqc6j+Ki4BU591ie1oL6qBQGu2Bl/tZ9ullr3+Kg0=
 collectd.org v0.3.0/go.mod h1:A/8DzQBkF6abtvrT2j/AU/4tiBgJWYyh0y/oB/4MlWE=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
+github.com/Azure/azure-kusto-go/azkustodata v1.1.0 h1:C3GuyExC0rHs8semXiL/eBXpRo1NcAexJzmz4CwPfZk=
+github.com/Azure/azure-kusto-go/azkustodata v1.1.0/go.mod h1:QF8waduO94gvbWLqGQPM2hwaGDcqETtK5PcDBbKMdHU=
 github.com/Azure/azure-sdk-for-go v52.5.0+incompatible h1:/NLBWHCnIHtZyLPc1P7WIqi4Te4CC23kIQyK3Ep/7lA=
 github.com/Azure/azure-sdk-for-go v52.5.0+incompatible/go.mod h1:9XXNKU+eRnpl9moKnB4QOLf1HestfXbmab5FXxiDBjc=
 github.com/Azure/azure-sdk-for-go/sdk/azcore v1.19.1 h1:5YTBM8QDVIBN3sxBil89WfdAAqDZbyJTgh688DSxX5w=
@@ -812,6 +814,8 @@ github.com/rs/cors v1.7.0/go.mod h1:gFx+x8UowdsKA9AchylcLynDq+nNFfI8FkUZdN/jGCU=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
 github.com/ryanuber/columnize v2.1.0+incompatible/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
+github.com/samber/lo v1.49.1 h1:4BIFyVfuQSEpluc7Fua+j1NolZHiEHEpaSEKdsH0tew=
+github.com/samber/lo v1.49.1/go.mod h1:dO6KHFzUKXgP8LDhU0oI8d2hekjXnGOu0DB8Jecxd6o=
 github.com/samuel/go-zookeeper v0.0.0-20190923202752-2cc03de413da/go.mod h1:gi+0XIa01GRL2eRQVjQkKGqKF3SF9vZR/HnPullcV2E=
 github.com/satori/go.uuid v1.2.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
 github.com/scaleway/scaleway-sdk-go v1.0.0-beta.7.0.20210223165440-c65ae3540d44/go.mod h1:CJJ5VAbozOl0yEw7nHB9+7BXTJbIn6h7W+f6Gau5IP8=
@@ -819,6 +823,8 @@ github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg
 github.com/segmentio/kafka-go v0.1.0/go.mod h1:X6itGqS9L4jDletMsxZ7Dz+JFWxM6JHfPOCvTvk+EJo=
 github.com/segmentio/kafka-go v0.2.0/go.mod h1:X6itGqS9L4jDletMsxZ7Dz+JFWxM6JHfPOCvTvk+EJo=
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
+github.com/shopspring/decimal v1.4.0 h1:bxl37RwXBklmTi0C79JfXCEBD1cqqHt0bbgBAGFp81k=
+github.com/shopspring/decimal v1.4.0/go.mod h1:gawqmDU56v4yIKSwfBSFip1HdCCXN8/+DMd9qYNcwME=
 github.com/shurcooL/httpfs v0.0.0-20190707220628-8d4bc4ba7749/go.mod h1:ZY1cvUeJuFPAdZ/B6v7RHavJWZn2YPVFQ1OSXhCGOkg=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/shurcooL/vfsgen v0.0.0-20181202132449-6a9ea43bcacd/go.mod h1:TrYk7fJVaAttu97ZZKrO9UbRa8izdowaMIZcxYMbVaw=
@@ -868,6 +874,8 @@ github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
 github.com/tinylib/msgp v1.0.2/go.mod h1:+d+yLhGm8mzTaHzB+wgMYrodPfmZrzkirds8fDWklFE=
+github.com/tj/assert v0.0.3 h1:Df/BlaZ20mq6kuai7f5z2TvPFiwC3xaWJSDQNiIS3Rk=
+github.com/tj/assert v0.0.3/go.mod h1:Ne6X72Q+TB1AteidzQncjw9PabbMp4PBMZ1k+vd1Pvk=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/uber/jaeger-client-go v2.25.0+incompatible h1:IxcNZ7WRY1Y3G4poYlx24szfsn/3LvK9QHCq9oQw8+U=
 github.com/uber/jaeger-client-go v2.25.0+incompatible/go.mod h1:WVhlPFC8FDjOFMMWRy2pZqQJSXxYSwNYOkTr/Z6d3Kk=

--- a/clusterloader2/pkg/measurement/common/apiserver_sli_duration.go
+++ b/clusterloader2/pkg/measurement/common/apiserver_sli_duration.go
@@ -1,0 +1,251 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"time"
+
+	"github.com/Azure/azure-kusto-go/azkustodata"
+	"github.com/Azure/azure-kusto-go/azkustodata/kql"
+	"github.com/Azure/azure-kusto-go/azkustodata/query"
+	"k8s.io/klog/v2"
+	"k8s.io/perf-tests/clusterloader2/pkg/measurement"
+	"k8s.io/perf-tests/clusterloader2/pkg/util"
+)
+
+// TODO: Add Kusto SDK imports when ready to enable real Kusto integration:
+// "github.com/Azure/azure-kusto-go/kusto"
+
+// KustoClient interface abstracts the Kusto client to allow for mock implementations
+type KustoClient interface {
+	Query(ctx context.Context, database string, query string) ([]KustoResult, error)
+	Close() error
+}
+
+const (
+	apiserverSLIMetricName = "APIServerSLILatency_kusto"
+)
+
+func init() {
+	if err := measurement.Register(apiserverSLIMetricName, createAPIServerSLIMetricMeasurement); err != nil {
+		klog.Fatalf("Cannot register %s: %v", apiserverSLIMetricName, err)
+	}
+}
+
+func createAPIServerSLIMetricMeasurement() measurement.Measurement {
+	return &apiserverSLIMetricMeasurement{
+		start:   time.Now(), // record the start time when the measurement is created
+		metrics: make(map[string]*MetricPoint),
+	}
+}
+
+// MetricPoint represents a single metric point from Kusto
+type MetricPoint struct {
+	Metric map[string]string `json:"metric"`
+	Value  []interface{}     `json:"value"`
+}
+
+// KustoResult represents the result from Kusto query
+type KustoResult struct {
+	Timestamp   time.Time `json:"Timestamp"`
+	Verb        string    `json:"verb"`
+	Resource    string    `json:"resource"`
+	Scope       string    `json:"scope"`
+	Subresource string    `json:"subresource"`
+	LeStr       string    `json:"leStr"`
+	Value       float64   `json:"Value"`
+}
+
+type apiserverSLIMetricMeasurement struct {
+	kustoEndpoint string
+	clusterID     string
+	database      string
+	kustoClient   *azkustodata.Client
+	metrics       map[string]*MetricPoint
+	start         time.Time
+	end           time.Time
+}
+
+// Dispose implements measurement.Measurement.
+func (e *apiserverSLIMetricMeasurement) Dispose() {
+	if e.kustoClient != nil {
+		e.kustoClient.Close()
+	}
+}
+
+// String implements measurement.Measurement.
+func (e *apiserverSLIMetricMeasurement) String() string {
+	return apiserverSLIMetricName
+}
+
+// createKustoClient creates a Kusto client with Azure CLI authentication
+func (e *apiserverSLIMetricMeasurement) createKustoClient() (*azkustodata.Client, error) {
+	kustoConnectionStringBuilder := azkustodata.NewConnectionStringBuilder(e.kustoEndpoint)
+	kustoConnectionString := kustoConnectionStringBuilder.WithAzCli()
+	client, err := azkustodata.New(kustoConnectionString)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create Kusto client: %v", err)
+	}
+	return client, nil
+}
+
+// Execute supports two actions:
+// - start - Records the start time for SLI metrics collection.
+// - gather - Collects, gathers and prints current SLI metrics.
+func (e *apiserverSLIMetricMeasurement) Execute(config *measurement.Config) ([]measurement.Summary, error) {
+	action, err := util.GetString(config.Params, "action")
+	if err != nil {
+		return nil, err
+	}
+
+	switch action {
+	case "start":
+		// Record the start time
+		e.start = time.Now()
+		klog.V(2).Infof("%s: starting apiserver SLI metrics collection at %s", e, e.start.Format(time.RFC3339))
+
+		return nil, nil
+
+	case "gather":
+		klog.V(2).Infof("%s: starting apiserver SLI collecting...", e)
+
+		var err error
+		// Get Kusto configuration from params
+		e.kustoEndpoint, _ = util.GetString(config.Params, "kustoEndpoint")
+		e.clusterID, _ = util.GetString(config.Params, "clusterID")
+		e.database, _ = util.GetString(config.Params, "database")
+		sleepDurationStr, _ := util.GetStringOrDefault(config.Params, "kustoSleep", "15m")
+
+		if e.clusterID == "" || e.kustoEndpoint == "" || e.database == "" {
+			return nil, fmt.Errorf("clusterID, kustoEndpoint or database parameters are required for gather action")
+		}
+
+		sleepDuration, err := time.ParseDuration(sleepDurationStr)
+
+		if err != nil {
+			return nil, fmt.Errorf("invalid kustoSleep duration %q: %v", sleepDurationStr, err)
+		}
+
+		// Set the end time for the query to be now minus the sleep duration since sleepDuration
+		// allows for data to be fully ingested into Kusto
+		e.end = time.Now().Add(-1 * sleepDuration)
+
+		e.kustoClient, err = e.createKustoClient()
+		if err != nil {
+			return nil, fmt.Errorf("failed to create Kusto client: %v", err)
+		}
+
+		// Start the periodic collection
+		e.collectMetrics()
+
+		klog.V(2).Infof("%s: gathering apiserver SLI metrics from %s to %s...", e, e.start, e.end)
+
+		// Convert collected metrics to JSON format
+		metricsArray := make([]*MetricPoint, 0, len(e.metrics))
+		for _, metric := range e.metrics {
+			metricsArray = append(metricsArray, metric)
+		}
+
+		content, err := util.PrettyPrintJSON(metricsArray)
+		if err != nil {
+			return nil, err
+		}
+
+		sliSummary := measurement.CreateSummary(apiserverSLIMetricName, "json", content)
+		return []measurement.Summary{sliSummary}, nil
+
+	default:
+		return nil, fmt.Errorf("unknown action %v", action)
+	}
+}
+
+// collectMetrics collects metrics from Kusto and converts them to the required format
+func (e *apiserverSLIMetricMeasurement) collectMetrics() {
+	klog.V(5).Infof("%s: collecting metrics from Kusto...", e)
+
+	// Mock Kusto query execution - replace this with actual Kusto SDK calls
+	results, err := e.executeKustoQuery()
+	if err != nil {
+		klog.Errorf("%s: failed to execute Kusto query: %v", e, err)
+		return
+	}
+	primary := results.Tables()[0]
+	recs, err := query.ToStructs[KustoResult](primary)
+
+	// Convert Kusto results to metric format
+	newMetrics := make(map[string]*MetricPoint)
+	for _, result := range recs {
+		metricKey := fmt.Sprintf("%s_%s_%s_%s_%s_%s", result.Subresource, result.Resource, result.Verb, result.Scope, result.LeStr, result.Timestamp)
+
+		metric := &MetricPoint{
+			Metric: map[string]string{
+				"__name__":    "apiserver_request_sli_duration_seconds_bucket",
+				"component":   "apiserver",
+				"subresource": result.Subresource,
+				"le":          result.LeStr,
+				"resource":    result.Resource,
+				"scope":       result.Scope,
+				"verb":        result.Verb,
+			},
+			Value: []interface{}{
+				0, // timestamp placeholder
+				strconv.FormatFloat(result.Value, 'f', -1, 64),
+			},
+		}
+
+		newMetrics[metricKey] = metric
+	}
+
+	// Update the metrics map
+	e.metrics = newMetrics
+
+	klog.V(5).Infof("%s: collected %d metrics", e, len(newMetrics))
+}
+
+// executeKustoQuery executes the Kusto query and returns results
+func (e *apiserverSLIMetricMeasurement) executeKustoQuery() (query.Dataset, error) {
+	if e.kustoClient == nil {
+		return nil, fmt.Errorf("Kusto client not initialized")
+	}
+
+	query := kql.New(`
+ApiserverRequestSliDurationSecondsBucket1mIncrease
+| where isnan(Value) == false 
+| where Timestamp between (_start .. _end)
+| where Labels.cluster_id == _clusterid
+| extend verb = tolower(Labels.verb)
+| extend resource = tolower(Labels.resource)
+| extend scope = tolower(Labels.scope)
+| extend subresource = tostring(Labels.subresource)
+| extend leStr = tostring(Labels.le)
+| project Timestamp, verb, resource, scope, subresource, leStr, Value
+| summarize Value = sum(Value) by Timestamp = bin(Timestamp, 5m), verb, resource, scope, subresource, leStr
+| project Timestamp, Verb=verb, Resource=resource, Scope=scope, Subresource=subresource, LeStr=leStr, Value`)
+	params := kql.NewParameters().AddDateTime("_start", e.start).AddDateTime("_end", e.end).AddString("_clusterid", e.clusterID)
+	klog.V(5).Infof("%s: executing Kusto query: %s", e, query.String())
+
+	// Execute the query using our interface
+	results, err := e.kustoClient.Query(context.Background(), e.database, query, azkustodata.QueryParameters(params))
+	if err != nil {
+		return nil, fmt.Errorf("failed to execute Kusto query: %v", err)
+	}
+
+	return results, nil
+}

--- a/clusterloader2/testing/load/config.yaml
+++ b/clusterloader2/testing/load/config.yaml
@@ -80,6 +80,7 @@
 
 {{$ADDITIONAL_MEASUREMENT_MODULES := DefaultParam .CL2_ADDITIONAL_MEASUREMENT_MODULES nil}}
 {{$ADDITIONAL_PHASES_MODULES := DefaultParam .CL2_ADDITIONAL_PHASES_MODULES nil}}
+{{$KUSTO_SLEEP := DefaultParam .KUSTO_SLEEP "15m"}}
 
 name: load
 namespace:
@@ -122,6 +123,12 @@ steps:
 - module:
     path: /modules/measurements.yaml
     params:
+      action: start
+- name: APIServerSLILatency_kusto_start
+  measurements:
+  - Identifier: APIServerSLILatencyKustoQuick
+    Method: APIServerSLILatency_kusto
+    Params:
       action: start
 
 {{if $ADDITIONAL_MEASUREMENT_MODULES}}
@@ -461,3 +468,22 @@ steps:
       complete: true
       testType: "policy-creation"
 {{end}}
+
+# Wait before querying Kusto to allow data to propagate.
+- name: APIServerSLILatency_kusto_wait
+  measurements:
+  - Identifier: QuickWait
+    Method: Sleep
+    Params:
+      duration: {{$KUSTO_SLEEP}}
+
+- name: APIServerSLILatency_kusto_wait
+  measurements:
+  - Identifier: APIServerSLILatencyKustoQuick
+    Method: APIServerSLILatency_kusto
+    Params:
+      action: gather
+      kustoSleep: {{$KUSTO_SLEEP}}
+      kustoEndpoint: ""
+      clusterID: ""
+      database: ""


### PR DESCRIPTION
- Introduce new metric `APIServerSLILatency_kusto` from Kusto in AKS cluster.
- Update `testing/load/config.yaml` to include related step for load testing.

